### PR TITLE
Fix #11. Use Authorization header instead of URL

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -6,12 +6,16 @@ var token;
 
 function fetchToken() {
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', authUrl, true, escape(username), escape(password));
+    var authHeader = "Basic " + btoa(username + ":" + password);
+
+    xhr.open('GET', authUrl, true);
+    xhr.setRequestHeader("Authorization", authHeader);
+
     xhr.onreadystatechange = function() {
-        if (xhr.readyState == 4) {
+        if (xhr.readyState == 4 && xhr.status === 200) {
             token = xhr.responseText.replace("\n", "");
         }
-    }
+    };
     xhr.send(null);
 }
 


### PR DESCRIPTION
According to the Chrome documentation:

Subresource requests whose URLs contain embedded credentials (e.g. https://user:pass@host/) are deprecated, and will be blocked in M59, around June 2017. See https://www.chromestatus.com/feature/5669008342777856 for more details.