### PR TITLE
Filter out empty lines from URL patterns.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -30,7 +30,7 @@ function updateSetting(url_pattern, user, auth_url, pass) {
 
 function updateAuthListener() {
     chrome.webRequest.onBeforeSendHeaders.removeListener(authListener);
-    var patterns = urlPatterns.split("\n");
+    var patterns = urlPatterns.split("\n").filter(function(p) { return p.trim().length > 0; });
     if (patterns) {
         chrome.webRequest.onBeforeSendHeaders.addListener(authListener,
             {"urls": patterns},


### PR DESCRIPTION
This PR fixes the issue with blank / trailing lines in the URL patterns.
Previously the plugin was simply logging an error when the url patterns field had empty or trailing lines.